### PR TITLE
Fix Attio capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # subnets-attio
-Parses new subnets directly to a list in attio
+Parses new subnets directly to a list in Attio.


### PR DESCRIPTION
## Summary
- fix capitalization of the Attio name in the README

## Testing
- `python -m py_compile sync_l1s.py`